### PR TITLE
fix(api): add confirm query param to hard delete endpoints

### DIFF
--- a/src/services/Careers/HardDelete.js
+++ b/src/services/Careers/HardDelete.js
@@ -1,7 +1,7 @@
 import apiInstance from '@utils/instances/ApiInstance';
 
 const hardDeleteCareer = async (id) => {
-  const response = await apiInstance.delete(`/carrers/${id}/hard`);
+  const response = await apiInstance.delete(`/carrers/${id}/hard?confirm=true`);
   return response.data;
 };
 

--- a/src/services/Faculties/HardDelete.js
+++ b/src/services/Faculties/HardDelete.js
@@ -1,7 +1,7 @@
 import apiInstance from '@utils/instances/ApiInstance';
 
 const hardDeleteFaculty = async (id) => {
-  const response = await apiInstance.delete(`/faculties/${id}/hard`);
+  const response = await apiInstance.delete(`/faculties/${id}/hard?confirm=true`);
   return response.data;
 };
 

--- a/src/services/Permissions/HardDelete.js
+++ b/src/services/Permissions/HardDelete.js
@@ -1,7 +1,7 @@
 import apiInstance from '@utils/instances/ApiInstance';
 
 const hardDeletePermission = async (id) => {
-  const response = await apiInstance.delete(`/permissions/${id}/hard`);
+  const response = await apiInstance.delete(`/permissions/${id}/hard?confirm=true`);
   return response.data;
 };
 


### PR DESCRIPTION
- Add required confirm=true query parameter to hard delete API calls to prevent accidental deletions